### PR TITLE
fix: decode self.command_output return type

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -423,9 +423,9 @@ class boost(Generator):
 
     def command_output(self, command):
         if sys.version_info.major >= 3:
-            return subprocess.check_output(command, shell=False, encoding=locale.getpreferredencoding()).strip()
+            return subprocess.check_output(command, shell=False, encoding=locale.getpreferredencoding()).strip().decode()
         else:
-            return subprocess.check_output(command, shell=False).strip()
+            return subprocess.check_output(command, shell=False).strip().decode()
 
     @property
     def apply_isysroot(self):


### PR DESCRIPTION
I'm on macOS 10.13 High Sierra.

self.command_output returns a binary string, which causes a warning when building Boost.

But it's worse than a warning, since the sysroot is incorrect, and Boost cannot be built.