### PR TITLE
Android fixes/1.66.0

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -50,7 +50,7 @@ class boost(Generator):
         # print("@@@@@@@@ BoostGenerator:boost.content: " + str(self.conanfile))
         try:
             jam_include_paths = ' '.join('"' + path + '"' for path in self.conanfile.deps_cpp_info.includedirs).replace('\\', '/')
-         
+
             libraries_to_build = " ".join(self.conanfile.lib_short_names)
 
             jamroot_content = self.get_template_content() \
@@ -451,18 +451,18 @@ class boost(Generator):
         if self.b2_os != 'windows' and self.b2_toolset in ['gcc', 'clang'] and self.b2_link == 'static':
             return '<flags>-fPIC\n<cxxflags>-fPIC'
         return ''
-    
+
     @property
     def b2_mpicxx(self):
         try:
             return str(self.conanfile.options.mpicxx)
         except:
             return ''
-    
+
     @property
     def b2_threading(self):
         return 'multi'
-    
+
     @property
     def b2_threadapi(self):
         try:

--- a/conanfile.py
+++ b/conanfile.py
@@ -212,16 +212,24 @@ class boost(Generator):
     def b2_toolset_exec(self):
         if self.b2_os in ['linux', 'freebsd', 'solaris', 'darwin', 'android'] or \
                 (self.b2_os == 'windows' and self.b2_toolset == 'gcc'):
-            version = str(self.settings.compiler.version).split('.')
-            result_x = self.b2_toolset.replace('gcc', 'g++') + "-" + version[0]
-            result_xy = result_x
-            if len(version) > 1:
-                result_xy += version[1] if version[1] != '0' else ''
 
             class dev_null(object):
 
                 def write(self, message):
                     pass
+
+
+            if 'CXX' in os.environ:
+                try:
+                    self.conanfile.run(os.environ['CXX'] + ' --version', output=dev_null())
+                    return os.environ['CXX']
+                except:
+                    pass
+            version = str(self.settings.compiler.version).split('.')
+            result_x = self.b2_toolset.replace('gcc', 'g++') + "-" + version[0]
+            result_xy = result_x
+            if len(version) > 1:
+                result_xy += version[1] if version[1] != '0' else ''
 
             try:
                 self.conanfile.run(result_xy + " --version", output=dev_null())

--- a/conanfile.py
+++ b/conanfile.py
@@ -514,8 +514,8 @@ class boost(Generator):
     def b2_profile_tools(self):
         if self.b2_toolset == 'gcc' or self.b2_toolset == 'clang':
             additional_flags = []
-            if 'CONAN_CMAKE_FIND_ROOT_PATH' in os.environ:
-                additional_flags.append('<root>%s' % os.environ['CONAN_CMAKE_FIND_ROOT_PATH'])
+            if 'SYSROOT' in os.environ:
+                additional_flags.append('<root>%s' % os.environ['SYSROOT'])
             if 'AR' in os.environ:
                 additional_flags.append('<archiver>%s' % os.environ['AR'])
             if 'RANLIB' in os.environ:

--- a/conanfile.py
+++ b/conanfile.py
@@ -210,7 +210,7 @@ class boost(Generator):
 
     @property
     def b2_toolset_exec(self):
-        if self.b2_os in ['linux', 'freebsd', 'solaris', 'darwin'] or \
+        if self.b2_os in ['linux', 'freebsd', 'solaris', 'darwin', 'android'] or \
                 (self.b2_os == 'windows' and self.b2_toolset == 'gcc'):
             version = str(self.settings.compiler.version).split('.')
             result_x = self.b2_toolset.replace('gcc', 'g++') + "-" + version[0]

--- a/conanfile.py
+++ b/conanfile.py
@@ -347,10 +347,10 @@ class boost(Generator):
 
     @property
     def b2_libcxx(self):
-        if self.b2_toolset == 'gcc':
+        if self.b2_toolset == 'gcc' and self.b2_os != 'android':
             if str(self.settings.compiler.libcxx) == 'libstdc++11':
                 return '<cxxflags>-std=c++11 <linkflags>-std=c++11'
-        elif self.b2_toolset == 'clang':
+        elif self.b2_toolset == 'clang' and self.b2_os != 'android':
             if str(self.settings.compiler.libcxx) == 'libc++':
                 return '<cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++'
             elif str(self.settings.compiler.libcxx) == 'libstdc++11':

--- a/jamroot.template
+++ b/jamroot.template
@@ -143,6 +143,7 @@ project boost
     {{{arch_flags}}}
     {{{isysroot}}}
     {{{fpic}}}
+    {{{profile_flags}}}
 :   build-dir bin
 :   default-build {{{variant}}}
     <target-os>{{{os}}}

--- a/project-config.template.jam
+++ b/project-config.template.jam
@@ -1,7 +1,7 @@
 import feature ;
 if ! {{{toolset}}} in [ feature.values <toolset> ]
 {
-    using {{{toolset}}} : {{{toolset_version}}} : "{{{toolset_exec}}}" ;
+    using {{{toolset}}} : {{{toolset_version}}} : "{{{toolset_exec}}}" {{{profile_tools}}} ;
 }
 local zlib_lib_paths = {{{zlib_lib_paths}}} ;
 local zlib_include_paths = {{{zlib_include_paths}}} ;


### PR DESCRIPTION
related to the https://github.com/bincrafters/community/issues/189

1. use b2_toolset_exec for Android as well (as it uses Clang, or GCC)
2. prefer CXX environment variable in b2_toolset_exec, as it might be set in conan profile in case of cross-compiling
3. handle additional environment variables which might be set in profile: CFLAGS, CXXFLAGS, LDFLAGS, AR, RANLIB, STRIP, CONAN_CMAKE_FIND_ROOT_PATH
4. for Android, do not use `-stdlib=libc++`, as it's harmful, and standalone toolchain already has the only standard library it is configured for. more, `-stdlib=libc++` implies `-lc++`, but standlone toolchain doesn't have libc++.a/libc++.so, only libc++_shared.so and libc++_static.a (which are auto-linked anyway). more information: https://github.com/conan-io/conan/issues/2402 https://github.com/conan-io/conan/issues/2049