### PR TITLE
Respect libcxx setting.

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -329,15 +329,17 @@ class boost(Generator):
     @property
     def b2_libcxx(self):
         if self.b2_toolset == 'gcc':
-            if str(self.settings.compiler.libcxx) == 'libstdc++11':
-                return '<cxxflags>-std=c++11 <linkflags>-std=c++11'
-        elif self.b2_toolset == 'clang':
-            if str(self.settings.compiler.libcxx) == 'libc++':
-                return '<cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++'
-            elif str(self.settings.compiler.libcxx) == 'libstdc++11':
-                return '<cxxflags>-stdlib=libstdc++ <linkflags>-stdlib=libstdc++ <cxxflags>-std=c++11 <linkflags>-std=c++11'
+            if self.settings.compiler.libcxx == 'libstdc++11':
+                return '<define>_GLIBCXX_USE_CXX11_ABI=1'
             else:
-                return '<cxxflags>-stdlib=libstdc++ <linkflags>-stdlib=libstdc++'
+                return '<define>_GLIBCXX_USE_CXX11_ABI=0'
+        elif self.b2_toolset == 'clang':
+            if self.settings.compiler.libcxx == 'libc++':
+                return '<cxxflags>-stdlib=libc++ <linkflags>-stdlib=libc++'
+            elif self.settings.compiler.libcxx == 'libstdc++11':
+                return '<cxxflags>-stdlib=libstdc++ <linkflags>-stdlib=libstdc++ <define>_GLIBCXX_USE_CXX11_ABI=1'
+            else:
+                return '<cxxflags>-stdlib=libstdc++ <linkflags>-stdlib=libstdc++ <define>_GLIBCXX_USE_CXX11_ABI=0'
         return ''
 
     @property

--- a/jamroot.template
+++ b/jamroot.template
@@ -131,15 +131,13 @@ local LIBPATH = {{{libpath}}} ;
 project boost
 :   requirements
     <define>BOOST_ALL_NO_LIB=1
+    {{{libcxx}}}
     <tag>@$(__name__).tag
     <link>shared,<runtime-link>static:<build>no
     <include>$(DEP_INCLUDES)
     <include>$(LIBRARIES)/include
-    <target-os>darwin:<cxxflags>-std=c++11
-    <target-os>darwin:<linkflags>-std=c++11
     <library-path>$(LIBPATH)
     <threadapi>{{{threadapi}}}
-    {{{libcxx}}}
     {{{arch_flags}}}
     {{{isysroot}}}
     {{{fpic}}}


### PR DESCRIPTION
Ensure that the libcxx setting actually affects the library in use.
This means setting the _GLIBCXX_USE_CXX11_ABI macro to select the
ABI if libstdc++ is in use, and using the -stdlib flag on clang.
Remove the use of the -std flag; it is not relevant.